### PR TITLE
added the variable to enable dns proxy for azure firewall policy and …

### DIFF
--- a/main_firewall_policy.tf
+++ b/main_firewall_policy.tf
@@ -14,5 +14,6 @@ module "firewall_policy" {
   firewall_policy_intrusion_detection           = var.firewall_policy_intrusion_detection
   tags                                          = var.azure_resource_tags
   firewall_policy_base_policy_id                = var.firewall_policy_base_policy_id
+  firewall_policy_dns                           = var.firewall_policy_dns
 
 }

--- a/variables_firewall_policy.tf
+++ b/variables_firewall_policy.tf
@@ -79,3 +79,18 @@ variable "firewall_policy_base_policy_id" {
   default     = null
   description = "(Optional) The ID of the base Firewall Policy."
 }
+
+variable "firewall_policy_dns" {
+  type = object({
+    proxy_enabled = optional(bool)
+    servers       = optional(list(string))
+  })
+  default     = {
+    proxy_enabled = true
+    servers = []
+  }
+  description = <<-EOT
+ - `proxy_enabled` - (Optional) Whether to enable DNS proxy on Firewalls attached to this Firewall Policy? Defaults to `false`.
+ - `servers` - (Optional) A list of custom DNS servers' IP addresses.
+EOT
+}


### PR DESCRIPTION
…set the default value to true

# Pull Request Template

## 📲 What

added a variable "firewall_policy_dns" and set the proxy_enabled attribute to _true_ and set servers attribute to [], initializing the server attribute with empty list

## 🤔 Why

The firewall application rules will need to have the dns proxy enabled to process the target/destination fqdns hence, enabling the proxy dns to use the azure dns as default.

## 🛠 How

By leaving the servers attribute as a empty list, the azure firewall policy would not apply any custom DNS servers.
with proxy_enabled attribute set to true, the firewall will likely default to azure provided DNS

## 👀 Evidence

Link to builds/artifacts/etc.

## 🕵️ How to test

Notes for QA

@ russellseymour @williamayerst @IamAndyW
